### PR TITLE
master: Add extra option parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following properties can be used:
 - `style` : _The style of the lines on the graph. Possibilites include
   `lines` (default), `points` and `linespoints`_
 - `nokey` : _Disables the graph key_
+- `options` : _Sets extra option parameters_
 
 The following example shows these in use:
 
@@ -71,7 +72,8 @@ plot({
 	logscale:	true,
 	xlabel:		'time',
 	ylabel:		'length of string',
-	format:		'pdf'
+	format:		'pdf',
+	options:	['xrange [0:120]', 'yrange [1000:2500]'],
 });
 ```
 

--- a/plotter.js
+++ b/plotter.js
@@ -114,7 +114,14 @@ function setup_gnuplot(gnuplot, options) {
   if (options.ylabel) {
     gnuplot.stdin.write('set ylabel "'+options.ylabel+'"\n');
   }
-
+  
+  /* Set extra option parameters */
+  if (options.options) {
+    for (var i = 0; i < options.options.length; i += 1) {
+      gnuplot.stdin.write('set '+options.options[i]+'\n');
+    }
+  }
+  
   /* Setup ticks */
   gnuplot.stdin.write('set grid xtics ytics mxtics\n');
   gnuplot.stdin.write('set mxtics\n');


### PR DESCRIPTION
Add extra option parameters to be able to set for example x and y range.
options:	['xrange [0:120]', 'yrange [1000:2500]'],