### PR TITLE
Added an option to set starting point on X axis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following properties can be used:
 - `style` : _The style of the lines on the graph. Possibilites include
   `lines` (default), `points` and `linespoints`_
 - `nokey` : _Disables the graph key_
+- `x_begin` : _Specifies the starting point along X axis on the graph_
 
 The following example shows these in use:
 
@@ -71,7 +72,8 @@ plot({
 	logscale:	true,
 	xlabel:		'time',
 	ylabel:		'length of string',
-	format:		'pdf'
+	format:		'pdf',
+	x_begin:	0
 });
 ```
 

--- a/plotter.js
+++ b/plotter.js
@@ -160,6 +160,10 @@ function plot(options) {
     options.style = 'lines'; /* Default to lines */
   }
 
+  if (!options.x_begin) {
+    options.x_begin = 0
+  }
+
   /* Apply moving averages and maximums */
   if (options.moving_avg) {
     options.data = apply_moving_filter(options.data, moving_average, options.moving_avg);
@@ -211,7 +215,7 @@ function plot(options) {
   /* Print out the data */
   for (i = 0; i < series.length; i += 1) { /* For each series */
     for (key in options.data[series[i]]) {
-      gnuplot.stdin.write(key + ' ' + options.data[series[i]][key] + '\n');
+      gnuplot.stdin.write(parseInt(options.x_begin) + parseInt(key) + ' ' + options.data[series[i]][key] + '\n');
     }
     /* Terminate the data */
     gnuplot.stdin.write('e\n');


### PR DESCRIPTION
When you want to plot a real math function it is better to at least specify the right X,Y coordinates for a specific point. So by setting the offset on X axis to match what you want to plot, you'll end up with a correct graph.

In this use case I'm assuming you're plotting your y values as follow:

```javascript
const data = []

for (let x = -25; x < 25; x += 1) {
  const y = someFunction(x)

  data.push(y)
}
```

As i start computing from x = -25, this option `x_begin` must be set on -25 as well.